### PR TITLE
diagram.json

### DIFF
--- a/diagram.json
+++ b/diagram.json
@@ -1,0 +1,79 @@
+{
+  "version": 1,
+  "editor": "wokwi",
+  "parts": [
+    { "type": "board-pi-pico-w", "id": "pico1", "top": 205.75, "left": 509.55, "attrs": {} },
+    { "type": "wokwi-membrane-keypad", "id": "keypad1", "top": -129, "left": -26, "attrs": {} },
+    {
+      "type": "wokwi-led",
+      "id": "led1",
+      "top": 311,
+      "left": 413.8,
+      "attrs": { "color": "green" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "led2",
+      "top": 426.2,
+      "left": 404.2,
+      "attrs": { "color": "red" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "led3",
+      "top": 368.6,
+      "left": 404.2,
+      "attrs": { "color": "blue" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "r1",
+      "top": 462.55,
+      "left": 323.6,
+      "attrs": { "value": "220" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "r2",
+      "top": 404.95,
+      "left": 323.6,
+      "attrs": { "value": "220" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "r3",
+      "top": 347.35,
+      "left": 323.6,
+      "attrs": { "value": "220" }
+    },
+    {
+      "type": "wokwi-buzzer",
+      "id": "bz1",
+      "top": 182.6,
+      "left": 642.2,
+      "attrs": { "volume": "0.1" }
+    }
+  ],
+  "connections": [
+    [ "led1:A", "pico1:GP11", "green", [ "v0" ] ],
+    [ "r3:2", "led1:C", "green", [ "v0" ] ],
+    [ "led3:A", "pico1:GP12", "green", [ "v0", "h19.2", "v-48" ] ],
+    [ "led3:C", "r2:2", "green", [ "v0" ] ],
+    [ "led2:A", "pico1:GP13", "green", [ "v0", "h28.8", "v-96", "h9.6" ] ],
+    [ "led2:C", "r1:2", "green", [ "v0" ] ],
+    [ "r3:1", "pico1:GND.4", "black", [ "v0", "h-67.2", "v144", "h230.4", "v-115.2" ] ],
+    [ "r2:1", "pico1:GND.4", "black", [ "v0", "h-67.2", "v86.4", "h230.4", "v-115.2" ] ],
+    [ "r1:1", "pico1:GND.4", "black", [ "v0", "h-67.2", "v28.8", "h230.4", "v-115.2" ] ],
+    [ "pico1:GND.6", "bz1:1", "black", [ "h0" ] ],
+    [ "bz1:2", "pico1:GP21", "green", [ "v0" ] ],
+    [ "keypad1:R1", "pico1:GP8", "green", [ "v105.6", "h336", "v-28.8" ] ],
+    [ "keypad1:R2", "pico1:GP7", "green", [ "v96", "h316.4", "v-19.2" ] ],
+    [ "keypad1:R3", "pico1:GP6", "green", [ "v86.4", "h297.3", "v-19.2" ] ],
+    [ "keypad1:R4", "pico1:GP5", "green", [ "v76.8", "h355", "v0", "v-9.6" ] ],
+    [ "keypad1:C1", "pico1:GP4", "green", [ "v67.2", "h335.9", "v-9.6" ] ],
+    [ "keypad1:C2", "pico1:GP3", "green", [ "v57.6", "h316.8", "v-9.6" ] ],
+    [ "keypad1:C3", "pico1:GP2", "green", [ "v48", "h297.45", "v-9.6" ] ],
+    [ "pico1:GP28", "keypad1:C4", "green", [ "h19.51", "v-76.8", "h-278.4", "v19.2", "h-182.1" ] ]
+  ],
+  "dependencies": {}
+}


### PR DESCRIPTION
Diagrama json completo, com a placa raspberry pi pico W, com três leds, três resistores, uma keypad e um buzzer. O led verde estando conectado na porta GPIO11, o led azul na porta GPIO12 e o led verde na porta GPIO13, com os resistores conectado no GND4; já o buzzer está conectado a porta GND6 e GPIO21. E por fim, em relação a keypad seus pino R1 está conectado a porta GPIO8, o pino R2 conectado a porta GPIO7, o pino R3 conectado a porta GPIO6, o pino R4 conectado a porta GPIO5, o pino C1 conectado a porta GPIO4, o pino C2 conectado a porta GPIO3, o pino C3 conectado a porta GPIO2 e o pino C4 conectado a porta GPIO28.